### PR TITLE
Improve hacs.json

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,4 @@
 {
   "name": "Roborock Custom Map",
-  "hacs": "0.1.1",
-  "homeassistant": "2025.3",
-  "domains": ["image"]
+  "homeassistant": "2025.4.0b0"
 }


### PR DESCRIPTION
This PR:
- removes `hacs` property - it is used to indicate minimal version of HACS, not current version of the integration
- changes minimal version of HA to 2025.4.0b0 - to allow installation only for HA 2025.4+
- removes deprecated `domains` property

More info: https://hacs.xyz/docs/publish/start/#hacsjson