### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -1,0 +1,17 @@
+---
+name: Validate HACS
+on:
+  push:
+  pull_request:
+jobs:
+  hacs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout code
+
+      - name: HACS Action
+        uses: hacs/action@main
+        with:
+          category: integration
+          ignore: brands

--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,0 +1,16 @@
+---
+name: Validate with hassfest
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  hassfest:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout code
+
+      - uses: home-assistant/actions/hassfest@master
+        name: Run hassfest validation

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+env:
+  COMPONENT_NAME: roborock_custom_map
+
+jobs:
+  release:
+    name: Prepare release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Download repo
+        uses: actions/checkout@v4
+
+      - name: Adjust version number
+        shell: bash
+        run: |
+          version="${{ github.event.release.tag_name }}"
+          yq e -P -o=json \
+            -i ".version = \"${version}\"" \
+            "${{ github.workspace }}/custom_components/${{ env.COMPONENT_NAME }}/manifest.json"
+
+      - name: Zip ${{ env.COMPONENT_NAME }} dir
+        run: |
+          cd "${{ github.workspace }}/custom_components/${{ env.COMPONENT_NAME }}"
+          zip ${{ env.COMPONENT_NAME }}.zip -r ./
+
+      - name: Upload zip to release
+        uses: softprops/action-gh-release@v2.1.0
+        with:
+          files: ${{ github.workspace }}/custom_components/${{ env.COMPONENT_NAME }}/${{ env.COMPONENT_NAME }}.zip

--- a/custom_components/roborock_custom_map/manifest.json
+++ b/custom_components/roborock_custom_map/manifest.json
@@ -8,6 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Lash-L/RoborockCustomMap/issues",
   "requirements": [],
-
   "version": "0.1.1"
 }


### PR DESCRIPTION
This PR adds 3 GitHub workflows:
 - Validate HACS
 - Validate with hassfest
 - Release
   - Things to do before first release:
     - Add following keys to `hacs.json`: 
       ```
        "zip_release": true,
        "filename": "roborock_custom_map.zip"
       ```
     - Set `version` in `manifest.json` to something like `0.0.0-main` (version from tag will be used automatically)